### PR TITLE
Add slayer tagged NPC count

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Features:
 + Highlight menu entries
 + Highlight minimap position
 + Filter to only highlight NPCs from a given list (must still be on your slayer task)
++ Infobox displaying the number of tagged NPCs
++ Notification when tagged NPC count falls below a threshold
 
 ![example1](https://i.imgur.com/iStLcK3.png)  
-![example2](https://i.imgur.com/ixYxtTo.png)
+![example2](https://i.imgur.com/DDng55i.png)

--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,11 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 	options.release.set(11)
 }
+
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = 'com.slayertaghighlight.SlayerTagHighlightPluginTest'
+
+	jvmArgs "-ea"
+	args "--developer-mode", "--debug"
+}

--- a/src/main/java/com/slayertaghighlight/SlayerTagHighlightConfig.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTagHighlightConfig.java
@@ -119,4 +119,46 @@ public interface SlayerTagHighlightConfig extends Config
 	)
 	default int outlineFeather() {return 2;}
 
+	@ConfigItem(
+			position = 12,
+			keyName = "showTaggedInfobox",
+			name = "Show Tagged Count Infobox",
+			description = "Show an infobox indicating the number of tagged NPCs"
+	)
+	default boolean showTaggedInfobox() {return false;}
+
+	@ConfigItem(
+			position = 13,
+			keyName = "taggedTimeoutMinutes",
+			name = "Tagged Infobox Expiry",
+			description = "Set the time until the tagged counter infobox expires"
+	)
+	@Units(Units.MINUTES)
+	default int taggedTimeoutMinutes()
+	{
+		return 5;
+	}
+
+	@ConfigItem(
+			position = 14,
+			keyName = "lowTaggedCountNotification",
+			name = "Low Tagged Count Notification",
+			description = "Enables notifications for the number of tagged NPCs"
+	)
+	default Notification lowTaggedCountNotification()
+	{
+		return Notification.OFF;
+	}
+
+	@ConfigItem(
+			position = 15,
+			keyName = "taggedCountNotificationThreshold",
+			name = "Low Tagged Count Threshold",
+			description = "The count of tagged NPCs to notify at"
+	)
+	default int lowTaggedCountNotificationThreshold()
+	{
+		return 0;
+	}
+
 }

--- a/src/main/java/com/slayertaghighlight/SlayerTagHighlightPlugin.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTagHighlightPlugin.java
@@ -48,6 +48,8 @@ public class SlayerTagHighlightPlugin extends Plugin {
 	@Inject
 	private SlayerTagHighlightConfig config;
 	@Inject
+	private SlayerTaggedCounterManager taggedCounter;
+	@Inject
 	private SlayerPluginService slayerPluginService;
 	@Inject
 	private PluginManager pluginManager;
@@ -59,6 +61,10 @@ public class SlayerTagHighlightPlugin extends Plugin {
 
 	@Getter
 	private ArrayList<NPC> highlights = new ArrayList<>();
+
+	@Getter
+	private int taggedCount = 0;
+
 	private List<String> filterNames;
 
 	@Override
@@ -76,21 +82,28 @@ public class SlayerTagHighlightPlugin extends Plugin {
 	protected void shutDown() {
 		overlayManager.remove(overlay);
 		overlayManager.remove(minimapOverlay);
+		taggedCounter.clear();
 	}
 
 	@Subscribe
 	public void onGameTick(GameTick event) {
 		highlights.clear();
+		int newTaggedCount = 0;
 		for (NPC npc : client.getNpcs()) {
 			if (slayerPluginService.getTargets().contains(npc)
 					&& !highlights.contains(npc)
-					&& !npc.isInteracting()
 					&& !npc.isDead()
 					&& (highlightMatchesNPCName(npc.getName()) || !config.filterByList())
 			) {
-				highlights.add(npc);
+				if (!npc.isInteracting()) {
+					highlights.add(npc);
+				} else {
+					newTaggedCount++;
+				}
 			}
 		}
+		taggedCounter.refresh(taggedCount, newTaggedCount);
+		taggedCount = newTaggedCount;
 	}
 
 	@Subscribe

--- a/src/main/java/com/slayertaghighlight/SlayerTagInfobox.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTagInfobox.java
@@ -1,0 +1,68 @@
+package com.slayertaghighlight;
+
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+import javax.inject.Inject;
+import java.awt.image.BufferedImage;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class SlayerTagInfobox {
+    @Inject
+    private InfoBoxManager infoBoxManager;
+
+    @Inject
+    private SlayerTagHighlightConfig config;
+    @Inject
+    private SlayerTagHighlightPlugin plugin;
+    @Inject
+    private ItemManager itemManager;
+
+    private SlayerTaggedCounter counter;
+
+    private Instant counterExpiresAt;
+
+    public void clear() {
+        if (counter != null) {
+            infoBoxManager.removeInfoBox(counter);
+            counter = null;
+            counterExpiresAt = null;
+        }
+    }
+
+    public void refresh(int count) {
+        if (!config.showTaggedInfobox()) {
+            clear();
+            return;
+        }
+
+        // Set live count
+        if (counter != null) {
+            counter.setCount(count);
+        }
+
+        if (count == 0) {
+            // Maintain counter expiry:
+            // - start a timer when count drops to 0
+            // - remove infobox when the timer expires
+            if (counterExpiresAt == null) {
+                counterExpiresAt = Instant.now().plus(config.taggedTimeoutMinutes(), ChronoUnit.MINUTES);
+            } else if (counterExpiresAt.isBefore(Instant.now())) {
+                clear();
+            }
+        } else {
+            // Reset expiry timer
+            counterExpiresAt = null;
+
+            // Create infobox if it does not exist
+            if (counter == null) {
+                BufferedImage image = itemManager.getImage(ItemID.BRONZE_DART);
+                counter = new SlayerTaggedCounter(image, plugin, count);
+                infoBoxManager.addInfoBox(counter);
+                counter.setTooltip("Number of tagged NPCs");
+            }
+        }
+    }
+}

--- a/src/main/java/com/slayertaghighlight/SlayerTagInfobox.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTagInfobox.java
@@ -47,9 +47,9 @@ public class SlayerTagInfobox {
             // Maintain counter expiry:
             // - start a timer when count drops to 0
             // - remove infobox when the timer expires
-            if (counterExpiresAt == null) {
+            if (counterExpiresAt == null && counter != null) {
                 counterExpiresAt = Instant.now().plus(config.taggedTimeoutMinutes(), ChronoUnit.MINUTES);
-            } else if (counterExpiresAt.isBefore(Instant.now())) {
+            } else if (counterExpiresAt != null && counterExpiresAt.isBefore(Instant.now())) {
                 clear();
             }
         } else {

--- a/src/main/java/com/slayertaghighlight/SlayerTaggedCounter.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTaggedCounter.java
@@ -1,0 +1,12 @@
+package com.slayertaghighlight;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.Counter;
+
+import java.awt.image.BufferedImage;
+
+public class SlayerTaggedCounter extends Counter {
+    public SlayerTaggedCounter(BufferedImage image, Plugin plugin, int count) {
+        super(image, plugin, count);
+    }
+}

--- a/src/main/java/com/slayertaghighlight/SlayerTaggedCounterManager.java
+++ b/src/main/java/com/slayertaghighlight/SlayerTaggedCounterManager.java
@@ -1,0 +1,28 @@
+package com.slayertaghighlight;
+
+import net.runelite.client.Notifier;
+
+import javax.inject.Inject;
+
+public class SlayerTaggedCounterManager {
+    @Inject
+    SlayerTagInfobox infobox;
+    @Inject
+    SlayerTagHighlightConfig config;
+    @Inject
+    private Notifier notifier;
+
+    public void clear() {
+        infobox.clear();
+    }
+
+    public void refresh(int oldCount, int newCount) {
+        infobox.refresh(newCount);
+
+        if (config.lowTaggedCountNotification().isEnabled()
+                && oldCount > config.lowTaggedCountNotificationThreshold()
+                && newCount <= config.lowTaggedCountNotificationThreshold()) {
+            notifier.notify(config.lowTaggedCountNotification(), "Tagged NPC Count is low");
+        }
+    }
+}


### PR DESCRIPTION
Track the count of tagged NPCs, and use this to feed an infobox (displays current tagged NPC count) and notification (notifies when count <= threshold).

New classes:
- `SlayerTagInfobox`: maintains infobox (given current tagged npc count, create/update/remove infobox)
- `SlayerTaggedCounter`: wrapper around runelite `Counter` class
- `SlayerTaggedCounterManager `: wrapper around infobox + notification handling
  - Notification handling is light weight, so it's handled inline in this wrapper